### PR TITLE
more work on transactions and buy

### DIFF
--- a/db.json
+++ b/db.json
@@ -11,11 +11,11 @@
     },
     {
       "email": "rudy@test.com",
-      "password": "$2a$10$tDxlKF8UepYYl9jsksdTp.CJilpJPzw/.oZkJRF0ZKbwId89cegI.",
+      "password": "$2a$10$zxgYAW9TNyHFseMu9SzYOuf93lDhCO6el9B7keSX5FnGn80TNe9Ai",
       "id": 1740074987696,
       "name": "Rudy Weiler",
-      "bankAccount": "987654321",
-      "balance": 2500
+      "bankAccount": "123456789",
+      "balance": 97358.47
     }
   ],
   "transactions": [
@@ -50,6 +50,230 @@
       "buyDate": 1740084063437,
       "buyPrice": 2755.54,
       "id": 4
+    },
+    {
+      "name": "Bitcoin",
+      "symbol": "BTC",
+      "amount": 1,
+      "buyDate": 1740084515921,
+      "buyPrice": 98637.4,
+      "id": 5
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Solana",
+      "symbol": "SOL",
+      "amount": 1,
+      "buyDate": 1740163498490,
+      "buyPrice": 171.85,
+      "id": 6
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Dogecoin",
+      "symbol": "DOGE",
+      "amount": 4,
+      "buyDate": 1740163639981,
+      "buyPrice": 0.25,
+      "id": 7
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 2,
+      "buyDate": 1740164135351,
+      "buyPrice": 1,
+      "id": 8
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Dogecoin",
+      "symbol": "DOGE",
+      "amount": 4,
+      "buyDate": 1740164752043,
+      "buyPrice": 0.25,
+      "id": 9
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "USDC",
+      "symbol": "USDC",
+      "amount": 10,
+      "buyDate": 1740167165407,
+      "buyPrice": 1,
+      "id": 10
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 10,
+      "buyDate": 1740167298175,
+      "buyPrice": 1,
+      "id": 11
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 5,
+      "buyDate": 1740167816874,
+      "buyPrice": 1,
+      "id": 12
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 5,
+      "buyDate": 1740167860634,
+      "buyPrice": 1,
+      "id": 13
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 5,
+      "buyDate": 1740167894810,
+      "buyPrice": 1,
+      "id": 14
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 5,
+      "buyDate": 1740168103077,
+      "buyPrice": 1,
+      "id": 15
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Ethena USDe",
+      "symbol": "USDE",
+      "amount": 5,
+      "buyDate": 1740168528722,
+      "buyPrice": 1,
+      "id": 16
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Dogecoin",
+      "symbol": "DOGE",
+      "amount": 4,
+      "buyDate": 1740169937614,
+      "buyPrice": 0.24,
+      "id": 17
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "USDC",
+      "symbol": "USDC",
+      "amount": 5,
+      "buyDate": 1740170579102,
+      "buyPrice": 1,
+      "id": 18
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "USDC",
+      "symbol": "USDC",
+      "amount": 5,
+      "buyDate": 1740170790510,
+      "buyPrice": 1,
+      "id": 19
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "USDC",
+      "symbol": "USDC",
+      "amount": 5,
+      "buyDate": 1740170810958,
+      "buyPrice": 1,
+      "id": 20
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Sui",
+      "symbol": "SUI",
+      "amount": 1,
+      "buyDate": 1740170933038,
+      "buyPrice": 3.27,
+      "id": 21
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Sui",
+      "symbol": "SUI",
+      "amount": 2,
+      "buyDate": 1740170954164,
+      "buyPrice": 3.27,
+      "id": 22
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Avalanche",
+      "symbol": "AVAX",
+      "amount": 1,
+      "buyDate": 1740171168676,
+      "buyPrice": 24.11,
+      "id": 23
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "USDC",
+      "symbol": "USDC",
+      "amount": 1,
+      "buyDate": 1740171353523,
+      "buyPrice": 1,
+      "id": 24
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 1,
+      "buyDate": 1740171488987,
+      "buyPrice": 1,
+      "id": 25
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Dogecoin",
+      "symbol": "DOGE",
+      "amount": 1,
+      "buyDate": 1740171739042,
+      "buyPrice": 0.24,
+      "id": 26
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "amount": 1,
+      "buyDate": 1740171963015,
+      "buyPrice": 2641.53,
+      "id": 27
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "amount": 1,
+      "buyDate": 1740172010751,
+      "buyPrice": 2641.53,
+      "id": 28
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "amount": 1,
+      "buyDate": 1740172142401,
+      "buyPrice": 2641.53,
+      "id": 29
     }
   ],
   "cryptos": [
@@ -76,6 +300,179 @@
       "symbol": "ETH",
       "amount": 2,
       "id": 4
+    },
+    {
+      "name": "Bitcoin",
+      "symbol": "BTC",
+      "amount": 1,
+      "id": 5
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Solana",
+      "symbol": "SOL",
+      "amount": 1,
+      "id": 6
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Dogecoin",
+      "symbol": "DOGE",
+      "amount": 4,
+      "id": 7
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 2,
+      "id": 8
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Dogecoin",
+      "symbol": "DOGE",
+      "amount": 4,
+      "id": 9
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "USDC",
+      "symbol": "USDC",
+      "amount": 10,
+      "id": 10
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 10,
+      "id": 11
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 5,
+      "id": 12
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 5,
+      "id": 13
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 5,
+      "id": 14
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 5,
+      "id": 15
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Ethena USDe",
+      "symbol": "USDE",
+      "amount": 5,
+      "id": 16
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Dogecoin",
+      "symbol": "DOGE",
+      "amount": 4,
+      "id": 17
+    },
+    {
+      "name": "",
+      "symbol": "",
+      "amount": 0,
+      "id": 18
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "USDC",
+      "symbol": "USDC",
+      "amount": 5,
+      "id": 19
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "USDC",
+      "symbol": "USDC",
+      "amount": 5,
+      "id": 20
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Sui",
+      "symbol": "SUI",
+      "amount": 1,
+      "id": 21
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Sui",
+      "symbol": "SUI",
+      "amount": 2,
+      "id": 22
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Avalanche",
+      "symbol": "AVAX",
+      "amount": 1,
+      "id": 23
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "USDC",
+      "symbol": "USDC",
+      "amount": 1,
+      "id": 24
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 1,
+      "id": 25
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Dogecoin",
+      "symbol": "DOGE",
+      "amount": 1,
+      "id": 26
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "amount": 1,
+      "id": 27
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "amount": 1,
+      "id": 28
+    },
+    {
+      "user_id": 1740074987696,
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "amount": 1,
+      "id": 29
     }
   ]
 }

--- a/src/app/components/coin-details/coin-details.component.ts
+++ b/src/app/components/coin-details/coin-details.component.ts
@@ -5,6 +5,8 @@ import { Crypto } from '../../models/crypto';
 import { TransactionService } from '../../services/transaction.service';
 import { Transaction } from '../../models/transaction';
 import { response } from 'express';
+import { User } from '../../models/user';
+import { UserService } from '../../services/user.service';
 
 
 
@@ -16,8 +18,9 @@ import { response } from 'express';
 })
 export class CoinDetailsComponent implements OnInit {
 
- 
-  currentUser: any = null;
+
+  currentUser: User = new User;
+  currentUserId: number = 0;
   currentCoinId: string = "";
   coin: any = null;
   closeValue: any = null;
@@ -27,70 +30,79 @@ export class CoinDetailsComponent implements OnInit {
   newCrypto: Crypto = new Crypto;
   amount: number = 0;
 
-  constructor(private cryptoService: CryptoService, private actRoute: ActivatedRoute, private router: Router, private transactionService: TransactionService) { }
+  constructor(private cryptoService: CryptoService, private actRoute: ActivatedRoute, private router: Router, private transactionService: TransactionService, private userService: UserService) { }
 
   ngOnInit(): void {
     this.currentCoinId = this.actRoute.snapshot.paramMap.get('coinId') ?? "";
     this.cryptoService.getCoinById(this.currentCoinId).subscribe(result => {
       this.coin = result;
       this.closeValue = parseFloat(this.coin.quotes.USD.price.toFixed(2));
-      
+
     });
-      this.cryptoService.getDescriptionById(this.currentCoinId).subscribe(result => {
+    this.cryptoService.getDescriptionById(this.currentCoinId).subscribe(result => {
       console.log(result);
       this.Description = result;
     });
     this.cryptoService.getTwitter(this.currentCoinId).subscribe(result => {
       this.TwitterFeed = result;
-    
+
     });
 
-    this.currentUser = JSON.parse(localStorage.getItem("currentUser") ?? "");
-    console.log(this.currentUser);
+    const user = JSON.parse(localStorage.getItem('currentUser')  ?? "");
+    this.currentUserId = parseFloat(user.user.id);
+    this.userService.getUserById(this.currentUserId).subscribe(result => {
+      console.log(result)
+      this.currentUser = result;
+    })
 
   }
 
+
+
+
+
   buy(coin: any) {
+    let totalCost = this.amount * this.closeValue;
+    console.log(totalCost);
+    if (this.currentUser.balance >= totalCost) {
+      this.currentUser.balance -= totalCost;
+      console.log(this.currentUser);
+      this.userService.updateUserById(this.currentUser.id, this.currentUser).subscribe(() => {
+      });
+      
+      this.newCrypto = {
+        id: undefined,
+        user_id: this.currentUser.id,
+        name: coin.name,
+        symbol: coin.symbol,
+        amount: this.amount,
+      }
+
+      
+      this.transactionService.createNewCrypto(this.newCrypto).subscribe(() => {
+      });
     
-    
 
-    this.newCrypto = {
-      id: undefined,
-      user_id: this.currentUser.user.user_id,
-      name: coin.name,
-      symbol: coin.symbol,
-      amount: this.amount,
+      this.newTransaction = {
+        id: undefined,
+        user_id: this.currentUser.id,
+        name: coin.name,
+        symbol: coin.symbol,
+        amount: this.amount,
+        buyDate: Date.now(),
+        buyPrice: this.closeValue,
+        sellDate: undefined,
+        sellPrice: undefined,
+        profitLoss: undefined,
+      }
+
+      
+
+      this.transactionService.createNewTransaction(this.newTransaction).subscribe(() => {
+      });
+
+      this.router.navigate(["/profile"]);
     }
-
-    this.newTransaction = {
-    id: undefined,
-    user_id: this.currentUser.user.user_id,
-    name: coin.name,
-    symbol: coin.symbol,
-    amount: this.amount,
-    buyDate:  Date.now(),
-    buyPrice: this.closeValue,
-    sellDate: undefined,
-    sellPrice: undefined,
-    profitLoss: undefined,
-    }
-
-    console.log(this.newCrypto);
-    console.log(this.newTransaction);
-
-    this.transactionService.createNewCrypto(this.newCrypto).subscribe(response => {
-      console.log(response);
-    });
-
-    this.transactionService.createNewTransaction(this.newTransaction).subscribe(response => {
-      console.log(response);
-    })
-
-    let totalcost = this.amount * this.closeValue;
-
-    this.currentUser.user.balance -= totalcost;
-     
-    this.router.navigate(["/profile"]);
 
   }
 

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -3,6 +3,7 @@ import { UserService } from '../../services/user.service';
 import { User } from '../../models/user';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
+import { stringify } from 'querystring';
 
 @Component({
   selector: 'app-login',
@@ -55,7 +56,7 @@ export class LoginComponent implements OnInit {
 
       this.userService.login(email, password).subscribe({
         next: (user: User) => {
-          localStorage.setItem('currentUser', JSON.stringify(user))
+            localStorage.setItem('currentUser', JSON.stringify(user));
           console.log('Login successful:', user);
           this.router.navigate(['/profile']);
         },

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -10,10 +10,13 @@
     <a class="nav-link" aria-current="Market" href="market">Market</a>
     
     <div class="nav justify-content-end">
-      <button *ngIf="userService.getCurrentUser()" 
+      <button 
+      
               class="btn btn-secondary" 
               (click)="logout()">
         Logout
       </button>
     </div>
 </nav>
+
+<!-- *ngIf="userService.getCurrentUser()" -->

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -15,16 +15,18 @@ export class ProfileComponent implements OnInit{
 
   currentUserId: number = 0;
   currentUser: User = new User;
-  test: any = null;
+  user: any = null;
   purchased: Crypto[] = []
   
   constructor(private userService: UserService, private router: Router) { }
 
   ngOnInit(): void {
-   this.test = localStorage.getItem("currentUser");
-   this.test = JSON.parse(this.test);
-   this.currentUser = this.test.user;
-   
+    const user = JSON.parse(localStorage.getItem('currentUser')  ?? "");
+    this.currentUserId = parseFloat(user.user.id);
+    this.userService.getUserById(this.currentUserId).subscribe(result => {
+      this.currentUser = result;
+    })
+    
    
   }
 }

--- a/src/app/services/transaction.service.ts
+++ b/src/app/services/transaction.service.ts
@@ -30,15 +30,19 @@ export class TransactionService {
     return this.http.put<Transaction>(`${this.transactionURL}/${TransactionId}`, edittedTransaction);
   }
 
-  getTransactionByCustomId(userId: number): Observable<Transaction> {
-    return this.http.get<Transaction>(`${this.transactionURL}?user_id=${userId}`);
+  getTransactionUserId(userId: number): Observable<Transaction[]> {
+    return this.http.get<Transaction[]>(`${this.transactionURL}?user_id=${userId}`);
   }
 
-  getCryptoByUserId(userId: number): Observable<Crypto> {
-    return this.http.get<Crypto>(`${this.cryptoURL}?user_id=${userId}`);
+  getCryptoByUserId(userId: number): Observable<Crypto[]> {
+    return this.http.get<Crypto[]>(`${this.cryptoURL}?user_id=${userId}`);
   }
 
   createNewCrypto(NewCrypto: Crypto): Observable<Crypto> {
     return this.http.post<Crypto>(this.cryptoURL, NewCrypto)
+  }
+
+  getCryptoBySymbolAndUserId(userId: number|undefined, CryptoSymbol: string): Observable<Crypto> {
+    return this.http.get<Crypto>(`${this.cryptoURL}/?symbol=${CryptoSymbol}&user_id=${userId}`)
   }
 }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
 import { catchError, Observable, tap, throwError } from 'rxjs';
 import { User } from '../models/user';
-import { Crypto } from '../models/crypto';
 
 @Injectable({
   providedIn: 'root'
@@ -27,16 +26,24 @@ export class UserService {
     return [];
   }
 
-  getCurrentUser(userId?: number): Observable<User> {
-    if (userId) {
-      return this.http.get<User>(`${this.apiUrl}/users/${userId}`);
-    }
-    const currentUser = JSON.parse(localStorage.getItem('currentUser') || 'null');
-    return new Observable<User>(observer => {
-      observer.next(currentUser as User);
-      observer.complete();
-    });
+  getUserById(userId: number): Observable<User> {
+    return this.http.get<User>(`${this.apiUrl}/users/${userId}`);
   }
+
+  updateUserById(userId: number|undefined, updatedUser: User): Observable<User> {
+    return this.http.put<User>(`${this.apiUrl}/users/${userId}`, updatedUser);
+  }
+
+  // getCurrentUser(userId?: number): Observable<User> {
+  //   if (userId) {
+  //     return this.http.get<User>(`${this.apiUrl}/users/${userId}`);
+  //   }
+  //   const currentUser = JSON.parse(localStorage.getItem('currentUser') || 'null');
+  //   return new Observable<User>(observer => {
+  //     observer.next(currentUser as User);
+  //     observer.complete();
+  //   });
+  // }
 
   logout(): Observable<void> {
     return this.http.post<void>(`${this.apiUrl}/logout`, {}).pipe(


### PR DESCRIPTION
OK, This allows the user to "buy" a coin. It puts a new transaction and coin in the database with the user Id attached, as well as, it updates the users balance. I think we need to modify this so that it only creates and new crypto entry if the user hasn't bought that coin before. If they have, the buy method, should just update their amount. I think we can accomplish this by checking first. I make a getCryptoBySymbolAndUser_ID() route in the transaction service. I didn't figure out how to make it functional, so I removed that logic from the buy method.