### PR TITLE
Go Back/Cancel Buttons added, started prompt for Buy

### DIFF
--- a/db.json
+++ b/db.json
@@ -14,7 +14,7 @@
       "id": 1741229357244,
       "name": "Brian W.",
       "bankAccount": "789456123",
-      "balance": 95430.51999999997
+      "balance": 113442.47
     }
   ],
   "transactions": [
@@ -170,7 +170,11 @@
       "amount": 53.185831294543135,
       "buyDate": 1741648884127,
       "buyPrice": 1880.2,
-      "id": 13
+      "id": 13,
+      "currentValue": 1919.86,
+      "sellDate": 1741738062718,
+      "sellPrice": 1919.86,
+      "profitLoss": 2109.35
     },
     {
       "user_id": 1740684281625,
@@ -201,6 +205,106 @@
       "buyDate": 1741721489210,
       "buyPrice": 1948.06,
       "id": 16
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "usdt-tether",
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 0,
+      "buyDate": 1741738453275,
+      "buyPrice": 1,
+      "id": 17
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "sol-solana",
+      "name": "Solana",
+      "symbol": "SOL",
+      "amount": 0,
+      "buyDate": 1741738477236,
+      "buyPrice": 125.49,
+      "id": 18
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "eth-ethereum",
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "amount": 0,
+      "buyDate": 1741738515803,
+      "buyPrice": 1919.68,
+      "id": 19
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "usdc-usd-coin",
+      "name": "USDC",
+      "symbol": "USDC",
+      "amount": 0,
+      "buyDate": 1741738695173,
+      "buyPrice": 1,
+      "id": 20
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "doge-dogecoin",
+      "name": "Dogecoin",
+      "symbol": "DOGE",
+      "amount": 93750,
+      "buyDate": 1741739664286,
+      "buyPrice": 0.16,
+      "id": 21
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "trx-tron",
+      "name": "TRON",
+      "symbol": "TRX",
+      "amount": 113636.36363636363,
+      "buyDate": 1741740722903,
+      "buyPrice": 0.22,
+      "id": 22
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "ada-cardano",
+      "name": "Cardano",
+      "symbol": "ADA",
+      "amount": 41095.890410958906,
+      "buyDate": 1741740794459,
+      "buyPrice": 0.73,
+      "id": 23
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "link-chainlink",
+      "name": "Chainlink",
+      "symbol": "LINK",
+      "amount": 2679.938744257274,
+      "buyDate": 1741740924793,
+      "buyPrice": 13.06,
+      "id": 24
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "avax-avalanche",
+      "name": "Avalanche",
+      "symbol": "AVAX",
+      "amount": 575.3739930955121,
+      "buyDate": 1741740969502,
+      "buyPrice": 17.38,
+      "id": 25
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "eth-ethereum",
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "amount": 10,
+      "buyDate": 1741741039927,
+      "buyPrice": 1909.74,
+      "id": 26
     }
   ],
   "cryptos": [
@@ -249,7 +353,7 @@
       "crypto_id": "eth-ethereum",
       "name": "Ethereum",
       "symbol": "ETH",
-      "amount": 53.185831294543135,
+      "amount": 10,
       "id": 6
     },
     {
@@ -291,6 +395,62 @@
       "symbol": "ETH",
       "amount": 10,
       "id": 11
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "usdt-tether",
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 0,
+      "id": 12
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "usdc-usd-coin",
+      "name": "USDC",
+      "symbol": "USDC",
+      "amount": 0,
+      "id": 13
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "doge-dogecoin",
+      "name": "Dogecoin",
+      "symbol": "DOGE",
+      "amount": 93750,
+      "id": 14
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "trx-tron",
+      "name": "TRON",
+      "symbol": "TRX",
+      "amount": 113636.36363636363,
+      "id": 15
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "ada-cardano",
+      "name": "Cardano",
+      "symbol": "ADA",
+      "amount": 41095.890410958906,
+      "id": 16
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "link-chainlink",
+      "name": "Chainlink",
+      "symbol": "LINK",
+      "amount": 2679.938744257274,
+      "id": 17
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "avax-avalanche",
+      "name": "Avalanche",
+      "symbol": "AVAX",
+      "amount": 575.3739930955121,
+      "id": 18
     }
   ]
 }

--- a/src/app/components/coin-details/coin-details.component.html
+++ b/src/app/components/coin-details/coin-details.component.html
@@ -29,7 +29,9 @@
                                 <input type="number" name="usd" [(ngModel)]="usdAmount" (ngModelChange)="updateAmount()"
                                 placeholder="Enter amount in USD">
                                 <br>
-                                <button class="btn btn-primary" style="margin-top: 10px;" type="submit">Buy</button>
+                                <button class="btn btn-primary" style="margin-top: 10px;"
+                                    (click)="openPrompt(coin)">Buy</button>
+                                <button class="btn btn-danger" style="margin-top: 10px;" routerLink="/market">Go Back</button>
                             </form>
                         </div>
                     </div>
@@ -52,3 +54,14 @@
     </div>
 </div>
 
+<div *ngIf="showPrompt" class="promptOverlay">
+    <div *ngIf="showPrompt" class="prompt-box">
+      <h3>Are you sure you want to sell the quantity of</h3>
+      <h3>{{buyingTransaction.amount}} - 
+        {{buyingTransaction.name}} for a Profit/Loss of: 
+        {{ (((buyingTransaction.amount) * (buyingTransaction.currentValue ?? 0 )) - ((buyingTransaction.amount) * (buyingTransaction.buyPrice)) )| currency: 'USD':true}}   </h3>
+  
+      <button (click)="onConfirm()" style="font-weight: 500;">Confirm</button>
+      <button (click)="onCancel()" style="font-weight: 500;">Cancel</button>
+    </div>
+  </div>

--- a/src/app/components/coin-details/coin-details.component.ts
+++ b/src/app/components/coin-details/coin-details.component.ts
@@ -27,6 +27,8 @@ export class CoinDetailsComponent implements OnInit {
   amount: number = 0;
   usdAmount: number = 0;
   conversionRate: number = 0;
+  showPrompt: boolean = false;
+  buyingTransaction: Transaction = new Transaction
 
   constructor(
     private cryptoService: CryptoService, 
@@ -75,7 +77,25 @@ export class CoinDetailsComponent implements OnInit {
     this.amount = this.usdAmount / this.conversionRate;
   }
 
-
+    // Open the prompt box
+    openPrompt(coin: any): void {
+      this.buyingTransaction = coin;
+      this.showPrompt = true;
+    }
+  
+    // Handle the confirmation action
+    onConfirm(): void {
+      this.showPrompt = false;  // Close the prompt
+      console.log(this.buyingTransaction);
+      this.buy(this.buyingTransaction);
+    }
+  
+    // Handle the cancel action
+    onCancel(): void {
+      this.showPrompt = false;  // Close the prompt
+      console.log('Transaction cancelled');
+      // Handle cancelation logic here
+    }
 
   buy(coin: any): void {
     let totalCost = parseFloat((this.amount * this.closeValue).toFixed(2));  

--- a/src/app/components/transaction-history/transaction-history.component.html
+++ b/src/app/components/transaction-history/transaction-history.component.html
@@ -16,8 +16,8 @@
           <th>Date, Time</th>
           <th>Crypto</th>
           <th>Amount</th>
-          <th>Buy Price/Coin</th>
-          <th>Current Value/Coin</th>
+          <th>Buy Price Per Coin</th>
+          <th>Current Value Per Coin</th>
           <th>Action</th>
         </tr>
       </thead>
@@ -70,14 +70,12 @@
 
 <div *ngIf="showPrompt" class="promptOverlay">
   <div *ngIf="showPrompt" class="prompt-box">
-    <h3>Are you sure you want to sell this transaction</h3>
-    <p>
-      Qty:
-      {{sellingTransaction.amount}} - 
-      {{sellingTransaction.name}} for a net value of: 
-      {{ (((sellingTransaction.amount) * (sellingTransaction.currentValue ?? 0 )) - ((sellingTransaction.amount) * (sellingTransaction.buyPrice)) )| currency: 'USD':true}}   
-    </p>
-    <button (click)="onConfirm()">Confirm</button>
-    <button (click)="onCancel()">Cancel</button>
+    <h3>Are you sure you want to sell the quantity of</h3>
+    <h3>{{sellingTransaction.amount}} - 
+      {{sellingTransaction.name}} for a Profit/Loss of: 
+      {{ (((sellingTransaction.amount) * (sellingTransaction.currentValue ?? 0 )) - ((sellingTransaction.amount) * (sellingTransaction.buyPrice)) )| currency: 'USD':true}}   </h3>
+
+    <button (click)="onConfirm()" style="font-weight: 500;">Confirm</button>
+    <button (click)="onCancel()" style="font-weight: 500;">Cancel</button>
   </div>
 </div>

--- a/src/app/components/transaction-history/transaction-history.component.ts
+++ b/src/app/components/transaction-history/transaction-history.component.ts
@@ -125,7 +125,6 @@ export class TransactionHistoryComponent implements OnInit {
         console.log(existinCrypto);
 
         this.transactionService.editCryptoById(existinCrypto.id, existinCrypto).subscribe(() => {
-
         });
 
         //update user balance
@@ -135,7 +134,6 @@ export class TransactionHistoryComponent implements OnInit {
         console.log(this.currentUser.balance);
 
         this.userService.updateUserById(this.currentUserID, this.currentUser).subscribe(() => {
-
         });
 
         //close transaction
@@ -146,10 +144,7 @@ export class TransactionHistoryComponent implements OnInit {
 
           this.router.navigate(['/profile']);
         });
-
       });
     });
   }
-
-
 }

--- a/src/app/components/transfer/transfer.component.html
+++ b/src/app/components/transfer/transfer.component.html
@@ -36,7 +36,6 @@
                                     </select>
                                 </div>
 
-
                                 <div class="mb-3">
                                     <label for="amount" class="form-label text-white">Amount</label>
                                     <input placeholder="0.00" type="number" name="amount" class="form-control" [(ngModel)]="transferAmount"/>
@@ -45,8 +44,7 @@
                                 <button type="submit" class="btn btn-outline-light form-label">
                                     Transfer
                                 </button>
-
-
+                                <button class="btn btn-outline-light form-label" routerLink="/profile">Cancel</button>
                             </form>
                         </div>
                     </div>

--- a/src/app/components/update/update.component.html
+++ b/src/app/components/update/update.component.html
@@ -66,14 +66,12 @@
                     </div>
                   </div>
                 </div>
-    
-    
                 <div class="d-flex gap-2">
                   <button type="submit" class="btn btn-primary"
                           [disabled]="!updateUserForm.valid">
                     Update
                   </button>
-                
+                  <button class="btn btn-danger" routerLink="/profile">Cancel</button>
                 </div>
               </form>
             </div>


### PR DESCRIPTION
I did change the wording of the prompt, removed the p tag and changed them to two lines of h3, and made the words of "confirm" and "cancel" buttons more bold.  Also, I added Back button to the Coin-details when given the option to purchase (routing it back to the market page), and included "Cancel" buttons to the transfer and update pages.  Started the prompt for the buy button but the API stopped working.  I think we hit a daily limit.