### PR TITLE
added the ability to only see transactions for one crypto

### DIFF
--- a/db.json
+++ b/db.json
@@ -6,7 +6,7 @@
       "id": 1740684281625,
       "name": "Rudy Weiler",
       "bankAccount": "987654321",
-      "balance": 76676.16000000003
+      "balance": 71113.83000000003
     },
     {
       "email": "bw@test.com",
@@ -14,7 +14,7 @@
       "id": 1741229357244,
       "name": "Brian W.",
       "bankAccount": "789456123",
-      "balance": 89483.31000000001
+      "balance": 113442.47
     }
   ],
   "transactions": [
@@ -77,6 +77,40 @@
       "id": 5
     },
     {
+      "user_id": 1741229357244,
+      "crypto_id": "eth-ethereum",
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "amount": 40,
+      "buyDate": 1741229496936,
+      "buyPrice": 2270.05,
+      "id": 6,
+      "currentValue": 1883.97,
+      "sellDate": 1741649791917,
+      "sellPrice": 1883.97,
+      "profitLoss": -15443.2
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "mkr-maker",
+      "name": "Maker",
+      "symbol": "MKR",
+      "amount": 80,
+      "buyDate": 1741229648939,
+      "buyPrice": 1356.59,
+      "id": 7
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "sol-solana",
+      "name": "Solana",
+      "symbol": "SOL",
+      "amount": 600,
+      "buyDate": 1741229704652,
+      "buyPrice": 148.61,
+      "id": 8
+    },
+    {
       "user_id": 1740684281625,
       "crypto_id": "near-near-protocol",
       "name": "Near Protocol",
@@ -133,6 +167,20 @@
       "profitLoss": 1111.05
     },
     {
+      "user_id": 1741229357244,
+      "crypto_id": "eth-ethereum",
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "amount": 53.185831294543135,
+      "buyDate": 1741648884127,
+      "buyPrice": 1880.2,
+      "id": 13,
+      "currentValue": 1919.86,
+      "sellDate": 1741738062718,
+      "sellPrice": 1919.86,
+      "profitLoss": 2109.35
+    },
+    {
       "user_id": 1740684281625,
       "crypto_id": "eth-ethereum",
       "name": "Ethereum",
@@ -169,6 +217,106 @@
       "sellDate": 1741887483758,
       "sellPrice": 1844.97,
       "profitLoss": -1030.9
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "usdt-tether",
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 0,
+      "buyDate": 1741738453275,
+      "buyPrice": 1,
+      "id": 17
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "sol-solana",
+      "name": "Solana",
+      "symbol": "SOL",
+      "amount": 0,
+      "buyDate": 1741738477236,
+      "buyPrice": 125.49,
+      "id": 18
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "eth-ethereum",
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "amount": 0,
+      "buyDate": 1741738515803,
+      "buyPrice": 1919.68,
+      "id": 19
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "usdc-usd-coin",
+      "name": "USDC",
+      "symbol": "USDC",
+      "amount": 0,
+      "buyDate": 1741738695173,
+      "buyPrice": 1,
+      "id": 20
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "doge-dogecoin",
+      "name": "Dogecoin",
+      "symbol": "DOGE",
+      "amount": 93750,
+      "buyDate": 1741739664286,
+      "buyPrice": 0.16,
+      "id": 21
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "trx-tron",
+      "name": "TRON",
+      "symbol": "TRX",
+      "amount": 113636.36363636363,
+      "buyDate": 1741740722903,
+      "buyPrice": 0.22,
+      "id": 22
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "ada-cardano",
+      "name": "Cardano",
+      "symbol": "ADA",
+      "amount": 41095.890410958906,
+      "buyDate": 1741740794459,
+      "buyPrice": 0.73,
+      "id": 23
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "link-chainlink",
+      "name": "Chainlink",
+      "symbol": "LINK",
+      "amount": 2679.938744257274,
+      "buyDate": 1741740924793,
+      "buyPrice": 13.06,
+      "id": 24
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "avax-avalanche",
+      "name": "Avalanche",
+      "symbol": "AVAX",
+      "amount": 575.3739930955121,
+      "buyDate": 1741740969502,
+      "buyPrice": 17.38,
+      "id": 25
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "eth-ethereum",
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "amount": 10,
+      "buyDate": 1741741039927,
+      "buyPrice": 1909.74,
+      "id": 26
     },
     {
       "user_id": 1740684281625,
@@ -291,6 +439,16 @@
       "sellDate": 1741888745031,
       "sellPrice": 1,
       "profitLoss": 0
+    },
+    {
+      "user_id": 1740684281625,
+      "crypto_id": "eth-ethereum",
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "amount": 3,
+      "buyDate": 1741893105268,
+      "buyPrice": 1854.11,
+      "id": 36
     }
   ],
   "cryptos": [
@@ -331,8 +489,32 @@
       "crypto_id": "btc-bitcoin",
       "name": "Bitcoin",
       "symbol": "BTC",
-      "amount": 2,
+      "amount": 1,
       "id": 5
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "eth-ethereum",
+      "name": "Ethereum",
+      "symbol": "ETH",
+      "amount": 10,
+      "id": 6
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "mkr-maker",
+      "name": "Maker",
+      "symbol": "MKR",
+      "amount": 80,
+      "id": 7
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "sol-solana",
+      "name": "Solana",
+      "symbol": "SOL",
+      "amount": 600,
+      "id": 8
     },
     {
       "user_id": 1740684281625,
@@ -355,16 +537,72 @@
       "crypto_id": "eth-ethereum",
       "name": "Ethereum",
       "symbol": "ETH",
-      "amount": 0,
+      "amount": 3,
       "id": 11
     },
     {
       "user_id": 1741229357244,
-      "crypto_id": "eth-ethereum",
-      "name": "Ethereum",
-      "symbol": "ETH",
-      "amount": 40,
+      "crypto_id": "usdt-tether",
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 0,
       "id": 12
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "usdc-usd-coin",
+      "name": "USDC",
+      "symbol": "USDC",
+      "amount": 0,
+      "id": 13
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "doge-dogecoin",
+      "name": "Dogecoin",
+      "symbol": "DOGE",
+      "amount": 93750,
+      "id": 14
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "trx-tron",
+      "name": "TRON",
+      "symbol": "TRX",
+      "amount": 113636.36363636363,
+      "id": 15
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "ada-cardano",
+      "name": "Cardano",
+      "symbol": "ADA",
+      "amount": 41095.890410958906,
+      "id": 16
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "link-chainlink",
+      "name": "Chainlink",
+      "symbol": "LINK",
+      "amount": 2679.938744257274,
+      "id": 17
+    },
+    {
+      "user_id": 1741229357244,
+      "crypto_id": "avax-avalanche",
+      "name": "Avalanche",
+      "symbol": "AVAX",
+      "amount": 575.3739930955121,
+      "id": 18
+    },
+    {
+      "user_id": 1740684281625,
+      "crypto_id": "usdt-tether",
+      "name": "Tether",
+      "symbol": "USDT",
+      "amount": 0,
+      "id": 19
     }
   ]
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -19,7 +19,8 @@ const routes: Routes = [
   { path: 'profile', component: ProfileComponent },
   { path: 'transfer', component: TransferComponent },
   { path: 'update', component: UpdateComponent },
-  { path: 'transaction-history', component: TransactionHistoryComponent }, 
+  { path: 'transaction-history', component: TransactionHistoryComponent },
+  { path: 'transaction-history/:cryptoId', component: TransactionHistoryComponent }, 
   { path: 'about-us', component: AboutUsComponent }
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { UpdateComponent } from './components/update/update.component';
 import { TransactionHistoryComponent } from './components/transaction-history/transaction-history.component';
 import { FooterComponent } from './components/footer/footer.component';
 import { AboutUsComponent } from './components/about-us/about-us.component';
+import { CommonModule } from '@angular/common';
 
 
 @NgModule({
@@ -39,7 +40,8 @@ import { AboutUsComponent } from './components/about-us/about-us.component';
     ScrollingModule,
     AppRoutingModule,
     ReactiveFormsModule,
-    FormsModule
+    FormsModule,
+    CommonModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/components/about-us/about-us.component.html
+++ b/src/app/components/about-us/about-us.component.html
@@ -16,7 +16,7 @@
                             <p class="description">Leading innovation in tech solutions</p>
                             <div class="social-links">
                                 <a href="https://www.linkedin.com/in/rudyweiler/" class="social-link" target="_blank" rel="noopener noreferrer">LinkedIn</a>
-                                <a href="https://www.linkedin.com/in/rudyweiler/" class="social-link" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+                                <a href="https://github.com/rudyweiler" class="social-link" target="_blank" rel="noopener noreferrer">GitHub</a>
                             </div>
                         </div>
                     </div>

--- a/src/app/components/coin-details/coin-details.component.html
+++ b/src/app/components/coin-details/coin-details.component.html
@@ -27,7 +27,7 @@
                                     placeholder="Enter amount in USD">
                                 <br>
                                 <button type="submit" class="btn btn-primary" style="margin-top: 10px;">Buy</button>
-                                <button class="btn btn-danger" style="margin-top: 10px;" (click)="goBack()">Go Back</button>
+                                <button class="btn btn-danger" style="margin-top: 10px; margin-left: 10px;" (click)="goBack()">Go Back</button>
                             </form>
                         </div>
                     </div>

--- a/src/app/components/profile/profile.component.html
+++ b/src/app/components/profile/profile.component.html
@@ -49,7 +49,7 @@
                             <tr *ngFor="let crypto of assets">
                                 <td><img id="cryptoIcon" style="max-width: 30px" src="https://static.coinpaprika.com/coin/{{crypto.crypto_id}}/logo.png"/></td>
                                 <td class="hover-text" [routerLink]='["/market", crypto.crypto_id]' >{{ crypto.name }}</td>
-                                <td>{{transactionDates.get(crypto.crypto_id) | date:'medium'}}</td>
+                                <td class="hover-text" [routerLink]='["/transaction-history", crypto.crypto_id]' >{{transactionDates.get(crypto.crypto_id) | date:'medium'}}</td>
                                 <td>{{ crypto.amount }}</td>
                                 <td>${{ valueMap.get(crypto.crypto_id)?.toFixed(2) || '0.00' }}</td>
                             </tr>

--- a/src/app/components/transaction-history/transaction-history.component.html
+++ b/src/app/components/transaction-history/transaction-history.component.html
@@ -9,7 +9,8 @@
 
   <!-- Open Transactions Table -->
   <div class="table-section">
-    <h3>Open Transactions</h3>
+    <h3 *ngIf="cryptoId">Open Transactions for Crypto: {{ cryptoId }}</h3>
+    <h3 *ngIf="!cryptoId">Open Transactions</h3>
     <table class="table table-dark">
       <thead>
         <tr class="table-active">
@@ -22,6 +23,14 @@
         </tr>
       </thead>
       <tbody>
+        <tr *ngIf="openTransactions.length == 0">
+          <td>No open transactions</td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
         <tr *ngFor="let transaction of openTransactions">
           <td>{{ transaction.buyDate | date:'short' }}</td>
           <td>{{ transaction.symbol }} ({{ transaction.name }})</td>
@@ -38,7 +47,8 @@
 
   <!-- Closed Transactions Table -->
   <div class="table-section">
-    <h3>Closed Transactions</h3>
+    <h3 *ngIf="cryptoId">Closed Transactions for Crypto: {{ cryptoId }}</h3>
+    <h3 *ngIf="!cryptoId">Closed Transactions</h3>
     <table class="table table-dark">
       <thead>
         <tr class="table-active">
@@ -50,6 +60,14 @@
         </tr>
       </thead>
       <tbody>
+        <tr *ngIf="closedTransactions.length == 0">
+          <td>No closed transactions</td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
         <tr *ngFor="let transaction of closedTransactions">
           <td>{{ transaction.buyDate | date:'short' }}</td>
           <td>{{ transaction.symbol }} ({{ transaction.name }})</td>
@@ -71,9 +89,10 @@
 <div *ngIf="showPrompt" class="promptOverlay">
   <div *ngIf="showPrompt" class="prompt-box">
     <h3>Are you sure you want to sell the quantity of</h3>
-    <h3>{{sellingTransaction.amount}} - 
-      {{sellingTransaction.name}} for a Profit/Loss of: 
-      {{ (((sellingTransaction.amount) * (sellingTransaction.currentValue ?? 0 )) - ((sellingTransaction.amount) * (sellingTransaction.buyPrice)) )| currency: 'USD': 'symbol' }}   </h3>
+    <h3>{{sellingTransaction.amount}} -
+      {{sellingTransaction.name}} for a Profit/Loss of:
+      {{ (((sellingTransaction.amount) * (sellingTransaction.currentValue ?? 0 )) - ((sellingTransaction.amount) *
+      (sellingTransaction.buyPrice)) )| currency: 'USD': 'symbol' }} </h3>
 
     <button (click)="onConfirm()" style="font-weight: 500;">Confirm</button>
     <button (click)="onCancel()" style="font-weight: 500;">Cancel</button>

--- a/src/app/components/transaction-history/transaction-history.component.ts
+++ b/src/app/components/transaction-history/transaction-history.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
 import { Transaction } from '../../models/transaction';
 import { TransactionService } from '../../services/transaction.service';
 import { UserService } from '../../services/user.service';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { CryptoService } from '../../services/coinPaprikaAPI.service';
 import { User } from '../../models/user';
 import { Crypto } from '../../models/crypto';
@@ -25,7 +25,9 @@ export class TransactionHistoryComponent implements OnInit {
   loading = false;
   error?: string;
   showPrompt: boolean = false;
-  sellingTransaction: Transaction = new Transaction
+  sellingTransaction: Transaction = new Transaction;
+  cryptoId: string | null = null;
+  cryptoIdPresent: boolean = false;
 
 
 
@@ -34,12 +36,50 @@ export class TransactionHistoryComponent implements OnInit {
     private transactionService: TransactionService,
     private router: Router,
     private coinPaprikaAPI: CryptoService,
+    private actRoute: ActivatedRoute,
     @Inject(PLATFORM_ID) private platformId: object
   ) { this.isBrowser = isPlatformBrowser(platformId); }
 
   ngOnInit(): void {
     const user = this.isBrowser? JSON.parse(localStorage.getItem('currentUser') ?? ""):"";
+    // load user
     this.loadUserData();
+
+    // load all transactions by user or by user and crypto
+    this.actRoute.paramMap.subscribe(params => {
+      this.cryptoId = params.get('cryptoId');
+
+      if(this.cryptoId) {
+        this.cryptoIdPresent = true;
+        this.transactionService.getTransactionsbyCryptoAndUserId(this.cryptoId, this.currentUser.id ?? 0).subscribe({
+          next: (transactions) => {
+            this.transactions = transactions;
+            this.splitTransactions();
+            this.openTransactions.forEach(t => this.getCurrentValue(t, t.crypto_id))
+            this.loading = false;
+          },
+          error: (err) => {
+            this.error = 'Failed to load transactions';
+            this.loading = false;
+          }
+        });
+      } else {
+        this.transactionService.getTransactionUserId(this.currentUserID).subscribe({
+          next: (transactions) => {
+            this.transactions = transactions;
+            this.splitTransactions();
+            this.openTransactions.forEach(t => this.getCurrentValue(t, t.crypto_id))
+            this.loading = false;
+          },
+          error: (err) => {
+            this.error = 'Failed to load transactions';
+            this.loading = false;
+          }
+        });
+      }
+
+    });
+    
   }
 
   private loadUserData(): void {
@@ -59,7 +99,6 @@ export class TransactionHistoryComponent implements OnInit {
       balance: user.user.balance,
       password: user.user.password
     };
-    this.loadTransactions();
   }
 
   private loadTransactions(): void {

--- a/src/app/services/transaction.service.ts
+++ b/src/app/services/transaction.service.ts
@@ -18,6 +18,10 @@ export class TransactionService {
     return this.http.get<Transaction[]>(this.transactionURL);
   }
 
+  getTransactionsbyCryptoAndUserId(cryptoId: string, UserId: number): Observable<Transaction[]> {
+    return this.http.get<Transaction[]>(`${this.transactionURL}?crypto_id=${cryptoId}&user_id=${UserId}`);
+  }
+
   getTransactionById(TransactionId: number): Observable<Transaction> {
     return this.http.get<Transaction>(`${this.transactionURL}/${TransactionId}`);
   }


### PR DESCRIPTION
Click on the date of purchase for each crypto on the profile page and it will take you to the transaction page, but only display transactions for the coin you clicked on.